### PR TITLE
Add ES configuration and request IP

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,7 +33,8 @@ gunzip *.gz
 Create an index for the documents you're about to push
 
 ```
-curl -XPUT 'http://localhost:9200/initializr/'
+$ cd util
+$ ./configure-index.sh http://localhost:9200 initializr
 ```
 
 == Parsing the logs

--- a/src/main/groovy/io/spring/initializr/statistics/elastic/ProjectRequestDocument.groovy
+++ b/src/main/groovy/io/spring/initializr/statistics/elastic/ProjectRequestDocument.groovy
@@ -10,6 +10,7 @@ import groovy.transform.ToString
 class ProjectRequestDocument {
 
 	long generationTimestamp
+	String requestIp
 	String groupId
 	String artifactId
 	String packageName

--- a/src/test/groovy/io/spring/initializr/statistics/elastic/ImportStatisticsItemProcessorTest.groovy
+++ b/src/test/groovy/io/spring/initializr/statistics/elastic/ImportStatisticsItemProcessorTest.groovy
@@ -24,6 +24,7 @@ class ImportStatisticsItemProcessorTest extends AbstractElasticTest {
 		def document = process('2015-12-29T00:00:21Z',
 				'start.spring.io - [29/12/2015:00:00:21 +0000] "GET /starter.zip?name=demo&groupId=com.example&artifactId=demo&version=0.0.1-SNAPSHOT&description=Demo+project+for+Spring+Boot&packageName=com.example&type=maven-project&packaging=jar&javaVersion=1.8&language=java&bootVersion=1.3.1.RELEASE&dependencies=web HTTP/1.1" 200 0 51235 "-" "Java/1.8.0_65" 10.10.66.39:49859 x_forwarded_for:"2.177.163.44, 162.158.88.109" x_forwarded_proto:"http" vcap_request_id:5596f056-aad8-4e4e-622b-613acd701559 response_time:0.09861743 app_id:b017e0be-2460-49fe-b986-7377eb773926')
 
+		assertEquals '2.177.163.44', document.requestIp
 		assertEquals 'com.example', document.groupId
 		assertEquals 'demo', document.artifactId
 		assertEquals 'com.example', document.packageName
@@ -40,6 +41,7 @@ class ImportStatisticsItemProcessorTest extends AbstractElasticTest {
 		def document = process('2015-05-29T00:00:21Z',
 				'start.spring.io - [29/12/2015:00:46:36 +0000] "POST /starter.tgz HTTP/1.1" 200 32 49931 "-" "curl/7.43.0" 10.10.66.39:45063 x_forwarded_for:"104.238.45.29, 108.162.215.204" x_forwarded_proto:"https" vcap_request_id:e68549aa-5117-498c-775e-a988a36ae1e0 response_time:0.080911139 app_id:b017e0be-2460-49fe-b986-7377eb773926')
 
+		assertEquals '104.238.45.29', document.requestIp
 		assertEquals 'org.test', document.groupId
 		assertEquals 'demo', document.artifactId
 		assertEquals 'demo', document.packageName
@@ -56,6 +58,7 @@ class ImportStatisticsItemProcessorTest extends AbstractElasticTest {
 		def document = process('2015-12-29T15:21:57Z',
 				'start.spring.io - [29/12/2015:21:57:18 +0000] "GET /pom.xml?&dependencies=data-jpa&type=maven-build&packaging=war&javaVersion=1.7&language=java&bootVersion=1.3.1.RELEASE&groupId=com.emc.esrs.dockerpcf&artifactId=cloudDbUtils&name=CloudDBUitls&description=&packageName=com.emc.esrs.dockerpcf.clouddbutils HTTP/1.1" 200 0 1635 "-" "IntelliJ IDEA" 10.10.66.39:32060 x_forwarded_for:"168.159.213.210, 108.162.219.112" x_forwarded_proto:"https" vcap_request_id:c6727a54-c3ee-4535-4463-39250f3edf3d response_time:0.040023006 app_id:b017e0be-2460-49fe-b986-7377eb773926')
 
+		assertEquals '168.159.213.210', document.requestIp
 		assertEquals 'com.emc.esrs.dockerpcf', document.groupId
 		assertEquals 'cloudDbUtils', document.artifactId
 		assertEquals 'com.emc.esrs.dockerpcf.clouddbutils', document.packageName
@@ -72,6 +75,7 @@ class ImportStatisticsItemProcessorTest extends AbstractElasticTest {
 		def document = process('2015-12-29T19:40:16Z',
 				'start.spring.io - [29/12/2015:19:40:16 +0000] "GET /build.gradle?&dependencies=h2&dependencies=data-rest&type=gradle-build&packaging=jar&javaVersion=1.8&language=java&bootVersion=1.3.1.RELEASE&groupId=com.vblazhnov.stats&artifactId=stats&name=stats&description=Statistics+collect&packageName=com.vblazhnov.stats HTTP/1.1" 200 0 921 "-" "IntelliJ IDEA (Minerva)" 10.10.2.247:2941 x_forwarded_for:"145.255.2.192, 141.101.80.79" x_forwarded_proto:"https" vcap_request_id:46205cf2-8d24-47e0-72f6-4657331beeed response_time:0.037459673 app_id:b017e0be-2460-49fe-b986-7377eb773926')
 
+		assertEquals '145.255.2.192', document.requestIp
 		assertEquals 'com.vblazhnov.stats', document.groupId
 		assertEquals 'stats', document.artifactId
 		assertEquals 'com.vblazhnov.stats', document.packageName
@@ -87,6 +91,8 @@ class ImportStatisticsItemProcessorTest extends AbstractElasticTest {
 	void decodeDependenciesParam() {
 		def document = process('2015-12-29T01:12:33Z',
 				'start.spring.io - [29/12/2015:01:12:33 +0000] "GET /starter.zip?dependencies=jersey%2Cjdbc%2Cmysql%2Ctest%2Clombok&artifactId=service-impl&type=maven-project&packaging=com.x.service HTTP/1.1" 200 0 51038 "-" "SpringBootCli/1.3.1.RELEASE" 10.10.66.39:1852 x_forwarded_for:"124.79.107.76, 108.162.215.117" x_forwarded_proto:"https" vcap_request_id:6ec1493e-cee5-491f-6fa1-328e9c118065 response_time:0.079351566 app_id:b017e0be-2460-49fe-b986-7377eb773926')
+
+		assertEquals '124.79.107.76', document.requestIp
 		assertEquals 'com.example', document.groupId
 		assertEquals 'service-impl', document.artifactId
 		assertEquals 'com.example', document.packageName
@@ -114,6 +120,14 @@ class ImportStatisticsItemProcessorTest extends AbstractElasticTest {
 		assertEquals 'jar', document.packaging
 		assertEquals 'maven-project', document.type
 		assertDependencies(['aop'], document.dependencies)
+	}
+
+	@Test
+	void parseUnknownIpAddress() {
+		def document = process('2015-12-29T01:12:33Z',
+				'start.spring.io - [29/12/2015:01:12:33 +0000] GET /starter.zip?name=mhts-poc&groupId=ogis&artifactId=ogis.poc&version=0.0.1-SNAPSHOT&description=Demo+project+for+Spring+Boot&packageName=jp.co.ogis&type=gradle-project&packaging=jar&javaVersion=1.7&language=java&bootVersion=1.3.0.RELEASE&dependencies=h2 HTTP/1.1" 200 0 54713 "-" "Java/1.7.0_79" 10.10.66.30:12630 x_forwarded_for:"unknown,158.201.127.1, 103.22.200.157" x_forwarded_proto:"http" vcap_request_id:4dd1dbc8-99fc-4a83-59a0-70ea5470b6be response_time:0.087656439 app_id:b017e0be-2460-49fe-b986-7377eb773926')
+
+		assertEquals '158.201.127.1', document.requestIp
 	}
 
 	ProjectRequestDocument process(String timestamp, String log) {

--- a/util/config/request.json
+++ b/util/config/request.json
@@ -1,0 +1,74 @@
+{
+  "request": {
+    "properties": {
+      "generationTimestamp": {
+        "type": "date",
+        "index": "not_analyzed"
+      },
+      "requestIp": {
+        "type": "ip",
+        "index": "not_analyzed"
+      },
+      "groupId": {
+        "type": "string",
+        "analyzer": "packagename"
+      },
+      "artifactId": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "packageName": {
+        "type": "string",
+        "analyzer": "packagename"
+      },
+      "bootVersion": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "javaVersion": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "language": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "packaging": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "type": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "dependencies": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "invalid": {
+        "type": "boolean",
+        "index": "not_analyzed"
+      },
+      "invalidJavaVersion": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "invalidLanguage": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "invalidPackaging": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "invalidType": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "invalidDependencies": {
+        "type": "string",
+        "index": "not_analyzed"
+      }
+    }
+  }
+}

--- a/util/config/settings.json
+++ b/util/config/settings.json
@@ -1,0 +1,3 @@
+{
+  "index.analysis.analyzer.packagename.tokenizer": "lowercase"
+}

--- a/util/configure-index.sh
+++ b/util/configure-index.sh
@@ -1,0 +1,43 @@
+#! /bin/sh
+
+# Clear and re-configure the search index.
+
+if [ $# != 2 ]; then cat << EOM
+
+    usage: $0 ENDPOINT INDEX
+
+    where ENDPOINT is the path to the ElasticSearch endpoint (or http://localhost:9200)
+      and INDEX is the name of the endpoint, e.g. 'initializr'
+
+EOM
+    exit
+fi
+
+
+ENDPOINT=$1
+INDEX=$2
+
+echo "\nDelete the existing index."
+curl -XDELETE "$ENDPOINT/$INDEX"
+sleep 1
+
+echo "\nCreate the index again."
+curl -X PUT $ENDPOINT/$INDEX -d '{ "number_of_shards" : 5, "number_of_replicas" : 0}'
+sleep 1
+echo "\nClosing index."
+curl -XPOST "$ENDPOINT/$INDEX/_close"
+sleep 1
+curl -XPUT $ENDPOINT/$INDEX/_settings -d @./config/settings.json
+sleep 1
+echo "\nInstall the mapping - do once per type/mapping file."
+curl -XPOST "$ENDPOINT/$INDEX/request/_mapping" -d @./config/request.json
+sleep 1
+curl -XPOST "$ENDPOINT/$INDEX/_open"
+sleep 1
+
+echo "\nCheck the settings."
+curl $ENDPOINT/$INDEX/_settings?pretty=true
+sleep 1
+
+echo "\nCheck the mappings."
+curl $ENDPOINT/$INDEX/_mapping?pretty=true


### PR DESCRIPTION
This commit adds a script to initialize index/types/mappings on the
ElasticSearch instance.

Also, a new field `requestIp` has been added to the indexed entries.
